### PR TITLE
1) Fix minor parsing issues in hue/saturation get'ing. Should reduce …

### DIFF
--- a/lib/KasaLightEffect.js
+++ b/lib/KasaLightEffect.js
@@ -7,7 +7,7 @@ const SET_LIGHT_EFFECT_METHOD = "set_lighting_effect"
 const LIGHTING_EFFECTS = require('./light-effects/_All_Effects');
 
 class KasaLightEffect {
-    constructor(log, config, effect, api, debug, uuid, device, customName) {
+    constructor(log, config, effect, api, debug, deviceString, uuid, device, customName) {
         if(!config) return;
 
         this.log = log;
@@ -21,6 +21,8 @@ class KasaLightEffect {
         this.Service = this.api.hap.Service;
         this.Characteristic = this.api.hap.Characteristic;
         this.Categories = this.api.hap.Categories;
+
+        this.deviceString = deviceString;
 
         if(customName != undefined) {
             this.effectJSON = this.effect;
@@ -52,8 +54,8 @@ class KasaLightEffect {
         //On = boolean
         this.deviceService.getCharacteristic(this.Characteristic.On)
             .onSet(async (state) => {
-                this.debugLog(`SetEffect: 'kasa --host ${this.ip} --lightstrip raw-command ${LIGHT_EFFECT_SERVICE} ${SET_LIGHT_EFFECT_METHOD} "${this.effectJSON}"'`);
-                exec(`kasa --host ${this.ip} --lightstrip raw-command ${LIGHT_EFFECT_SERVICE} ${SET_LIGHT_EFFECT_METHOD} "${this.effectJSON}"`, (err, stdout, stderr) => {
+                this.debugLog(`SetEffect: 'kasa --host ${this.ip} ${this.deviceString} raw-command ${LIGHT_EFFECT_SERVICE} ${SET_LIGHT_EFFECT_METHOD} "${this.effectJSON}"'`);
+                exec(`kasa --host ${this.ip} ${deviceString} raw-command ${LIGHT_EFFECT_SERVICE} ${SET_LIGHT_EFFECT_METHOD} "${this.effectJSON}"`, (err, stdout, stderr) => {
                     if(err) {
                         this.log.info(`${this.name} - Error enabling effect ${this.effect}`);
                         this.debugLog(`SetEffect - Error - ${this.name}: ${stderr.trim()}`);

--- a/lib/KasaLightEffect.js
+++ b/lib/KasaLightEffect.js
@@ -55,7 +55,7 @@ class KasaLightEffect {
         this.deviceService.getCharacteristic(this.Characteristic.On)
             .onSet(async (state) => {
                 this.debugLog(`SetEffect: 'kasa --host ${this.ip} ${this.deviceString} raw-command ${LIGHT_EFFECT_SERVICE} ${SET_LIGHT_EFFECT_METHOD} "${this.effectJSON}"'`);
-                exec(`kasa --host ${this.ip} ${deviceString} raw-command ${LIGHT_EFFECT_SERVICE} ${SET_LIGHT_EFFECT_METHOD} "${this.effectJSON}"`, (err, stdout, stderr) => {
+                exec(`kasa --host ${this.ip} ${this.deviceString} raw-command ${LIGHT_EFFECT_SERVICE} ${SET_LIGHT_EFFECT_METHOD} "${this.effectJSON}"`, (err, stdout, stderr) => {
                     if(err) {
                         this.log.info(`${this.name} - Error enabling effect ${this.effect}`);
                         this.debugLog(`SetEffect - Error - ${this.name}: ${stderr.trim()}`);

--- a/lib/KasaLightstrip.js
+++ b/lib/KasaLightstrip.js
@@ -4,7 +4,7 @@ const PLUGIN_NAME = 'homebridge-kasa-lightstrip';
 const PLATFORM_NAME = 'HomebridgeKasaLightstrip';
 
 class KasaLightstrip {
-    constructor(log, config, api, debug, uuid, device) {
+    constructor(log, config, api, debug, deviceString, uuid, device) {
         if(!config) return;
 
         this.log = log;
@@ -13,6 +13,7 @@ class KasaLightstrip {
         this.debug = debug;
         this.uuid = uuid;
         this.device = device;
+        this.deviceString = deviceString;
 
         this.Service = this.api.hap.Service;
         this.Characteristic = this.api.hap.Characteristic;
@@ -53,8 +54,8 @@ class KasaLightstrip {
         this.deviceService.getCharacteristic(this.Characteristic.On)
             .onSet(async (state) => {
                 var translatedState = (state == true) ? "on":"off";
-                this.debugLog(`SetPower: 'kasa --host ${this.ip} --lightstrip ${translatedState}'`);
-                exec(`kasa --host ${this.ip} --lightstrip ${translatedState}`, (err, stdout, stderr) => {
+                this.debugLog(`SetPower: 'kasa --host ${this.ip} ${this.deviceString} ${translatedState}'`);
+                exec(`kasa --host ${this.ip} ${this.deviceString} ${translatedState}`, (err, stdout, stderr) => {
                     if(err) {
                         this.log.info(this.name + " - Error setting characteristic 'On'");
                         this.debugLog("SetPower - Error - " + this.name + ": " + stderr.trim());
@@ -64,16 +65,20 @@ class KasaLightstrip {
             }).onGet(async () => {
                 if(!this.checkingOn) {
                     this.checkingOn = true;
-                    this.debugLog(`GetPower: 'kasa --host ${this.ip} --lightstrip'`);
-                    exec(`kasa --host ${this.ip} --lightstrip`, (err, stdout, stderr) => {
+                    this.debugLog(`GetPower: 'kasa --host ${this.ip} ${this.deviceString}'`);
+                    exec(`kasa --host ${this.ip} ${this.deviceString}`, (err, stdout, stderr) => {
                         if(err) {
                             this.log.info(this.name + " - Error getting characteristic 'On'");
                             this.debugLog("GetPower - Error - " + this.name + ": " + stderr.trim());
                         } else {
-                            stdout = stdout.split("\n")[2].trim();
-                            this.debugLog(stdout);
-                            this.onStatus = stdout.includes("Device state: ON");
-                            this.deviceService.updateCharacteristic(this.Characteristic.On, this.onStatus);   //keep in sync in case the light was turned on elsewhere
+                            try {
+                                stdout = stdout.split("\n")[2].trim();
+                                this.debugLog(stdout);
+                                this.onStatus = stdout.includes("Device state: ON");
+                                this.deviceService.updateCharacteristic(this.Characteristic.On, this.onStatus);   //keep in sync in case the light was turned on elsewhere
+                            } catch (error) {
+                                this.ParseError(error);
+                            }
                         }
                         this.checkingOn = false;
                     });
@@ -84,8 +89,8 @@ class KasaLightstrip {
         //Brightness = int
         this.deviceService.getCharacteristic(this.Characteristic.Brightness)
             .onSet(async (state) => {
-                this.debugLog(`SetBrightness: 'kasa --host ${this.ip} --lightstrip brightness ${state}'`);
-                exec(`kasa --host ${this.ip} --lightstrip brightness ${state}`, (err, stdout, stderr) => {
+                this.debugLog(`SetBrightness: 'kasa --host ${this.ip} ${this.deviceString} brightness ${state}'`);
+                exec(`kasa --host ${this.ip} ${this.deviceString} brightness ${state}`, (err, stdout, stderr) => {
                     if(err) {
                         this.log.info(this.name + " - Error setting characteristic 'Brightness'");
                         this.debugLog("SetBrightness - Error - " + this.name + ": " + stderr.trim());
@@ -95,15 +100,19 @@ class KasaLightstrip {
             }).onGet(async () => {
                 if(!this.checkingBrightness) {
                     this.checkingBrightness = true;
-                    this.debugLog(`GetBrightness: 'kasa --host ${this.ip} --lightstrip brightness'`);
-                    exec(`kasa --host ${this.ip} --lightstrip brightness`, (err, stdout, stderr) => {
+                    this.debugLog(`GetBrightness: 'kasa --host ${this.ip} ${this.deviceString} brightness'`);
+                    exec(`kasa --host ${this.ip} ${this.deviceString} brightness`, (err, stdout, stderr) => {
                         if(err) {
                             this.log.info(this.name + " - Error getting characteristic 'Brightness'");
                             this.debugLog("GetBrightness - Error - " + stderr.trim());
                         } else {
-                            stdout = stdout.split("\n")[0].trim();
-                            this.debugLog(stdout);
-                            this.brightness = stdout.split("Brightness: ")[1];
+                            try {
+                                stdout = stdout.split("\n")[0].trim();
+                                this.debugLog(stdout);
+                                this.brightness = stdout.split("Brightness: ")[1];
+                            } catch (error) {
+                                ParseError(error);
+                            }
                         }
                         this.checkingBrightness = false;
                     });
@@ -120,16 +129,20 @@ class KasaLightstrip {
             }).onGet(async () => {
                 if(!this.checkingHSV) {
                     this.checkingHSV = true;
-                    this.debugLog(`GetHue: 'kasa --host ${this.ip} --lightstrip hsv'`);
-                    exec(`kasa --host ${this.ip} --lightstrip hsv`, (err, stdout, stderr) => {
+                    this.debugLog(`GetHue: 'kasa --host ${this.ip} ${this.deviceString} hsv'`);
+                    exec(`kasa --host ${this.ip} ${this.deviceString} hsv`, (err, stdout, stderr) => {
                         if(err) {
                             this.log.info(this.name + " - Error getting characteristic 'Hue/Saturation'");
                             this.debugLog("GetHue - Error - " + this.name + ": " + stderr.trim());
                         } else {
-                            stdout = stdout.split("\n")[0].trim();
-                            this.debugLog(stdout);  //expects "Current HSV: ($h, $s, $b)"
-                            this.hue = (stdout.split("(")[1]).split(",")[0].trim();
-                            this.saturation = (stdout.split("(")[1]).split(",")[1].trim();
+                            try {
+                                stdout = stdout.split("\n")[0].trim();
+                                this.debugLog(stdout);  //expects "Current HSV: ($h, $s, $b)"
+                                this.hue = (stdout.split("(")[1]).split(",")[0].split("=")[1];
+                                this.saturation = (stdout.split("(")[1]).split(",")[1].split("=")[1];
+                            } catch (error) {
+                                this.ParseError(error);
+                            }
                         }
                         this.checkingHSV = false;
                     });
@@ -149,12 +162,17 @@ class KasaLightstrip {
 
     //helpers
 
+    ParseError(error) {
+        this.log.info(this.name + " - Error parsing python-kasa output: " + error);
+        this.log.info("This may be an indicator you need to install python-kasa, preferably 0.4.1 or greater; visit https://github.com/steveredden/homebridge-kasa-lightstrip/blob/main/README.md for instructions");
+    }
+
     SetColor() {
         if(this.tempHue != undefined && this.tempSaturation != undefined) {
             let hue = this.tempHue;
             let saturation = this.tempSaturation;
-            this.debugLog(`SetColor: 'kasa --host ${this.ip} --lightstrip hsv ${hue} ${saturation} ${this.brightness}'`);
-            exec(`kasa --host ${this.ip} --lightstrip hsv ${hue} ${saturation} ${this.brightness}`, (err, stdout, stderr) => {
+            this.debugLog(`SetColor: 'kasa --host ${this.ip} ${this.deviceString} hsv ${hue} ${saturation} ${this.brightness}'`);
+            exec(`kasa --host ${this.ip} ${this.deviceString} hsv ${hue} ${saturation} ${this.brightness}`, (err, stdout, stderr) => {
                 if(err) {
                     this.log.info(this.name + " - Error setting characteristic 'Hue/Saturation'");
                     this.debugLog("SetColor - Error - " + this.name + ": " + stderr.trim());

--- a/lib/KasaLightstripPlatform.js
+++ b/lib/KasaLightstripPlatform.js
@@ -1,3 +1,5 @@
+let exec = require('child_process').exec;
+
 const KasaLightstrip = require("./KasaLightstrip");
 const KasaLightEffect = require("./KasaLightEffect");
 
@@ -15,7 +17,14 @@ class KasaLightstripPlatform {
         this.api = api;
         this.debug = this.config.debug || false;
 
-        this.api.on('didFinishLaunching', () => {
+        this.deviceString = undefined;
+        this.pythonKasaErrorMessage = "# Unable to run \"kasa --version\" successfully (or parse its results) during initialization; the most likely cause is needing to install python-kasa. See https://github.com/steveredden/homebridge-kasa-lightstrip/blob/main/README.md" // because this error will become part of the command string, prefix it with # so it's not interpreted as part of a command
+        this.pythonKasaVersion = undefined;
+
+        this.api.on('didFinishLaunching', async () => {
+            await this.setPythonKasaVersion();
+            await this.setDeviceString();
+
             if(this.config.accessories && Array.isArray(this.config.accessories)) {
 
                 //loop through each lightstrp in array
@@ -24,7 +33,7 @@ class KasaLightstripPlatform {
                     //Lightbulbs
                     const uuid = this.api.hap.uuid.generate('homebridge-kasa-lightstrip' + lightstrip.name + lightstrip.ip );
                     let accessory = this.accessories.find(accessory => accessory.UUID === uuid)
-                    new KasaLightstrip(this.log, lightstrip, this.api, this.debug, uuid, accessory);  
+                    new KasaLightstrip(this.log, lightstrip, this.api, this.debug, this.deviceString, uuid, accessory);
 
                     //Lighting Effect Switches / "buttons"
                     for (let effect in lightstrip.effects) {
@@ -66,6 +75,49 @@ class KasaLightstripPlatform {
         this.api.unregisterPlatformAccessories(PLUGIN_NAME, PLATFORM_NAME, [accessory]);
         this.log.info(`Removed ${accessory.displayName} [${accessory.UUID}]`);
     }
+
+    setDeviceString() {
+        return new Promise((resolve, reject) => {
+            if (this.pythonKasaVersion == "0.0.0") {
+                // treat 0.0.0 as an error, so that HB will continue, and debug messages will print our error string
+                // this may help avoid a lot of missing python-kasa questions
+                this.deviceString = this.pythonKasaErrorMessage;
+                resolve(this.deviceString);
+                return 0;
+            }
+            var SEMVER = this.pythonKasaVersion.split(".", 3);
+            var MAJOR = SEMVER[0];
+            var MINOR = SEMVER[1];
+            var PATCH = SEMVER[2];
+            if (MAJOR > 0 || (MAJOR == 0 && MINOR >4) || (MAJOR == 0 && MINOR == 4 && PATCH >= 1)) {
+                this.deviceString = "--type lightstrip";
+            } else {
+                this.deviceString = "--lightstrip";
+            }
+            resolve(this.deviceString);
+        });
+    }
+
+    setPythonKasaVersion() {
+        return new Promise((resolve,reject) => {
+            exec(`kasa --version`, (err, stdout, stderr) => {
+                if(err) {
+                    this.pythonKasaVersion = "0.0.0";
+                    resolve(this.pythonKasaVersion);
+                } else {
+                    try {
+                        this.pythonKasaVersion = stdout.split("kasa, version ")[1].trim();
+                        this.log.info("Got python-kasa version: " + this.pythonKasaVersion);
+                    } catch (error) {
+                        this.log.info("Error parsing python-kasa version; setting to 0.0.0");
+                        this.pythonKasaVersion = "0.0.0";
+                    }
+                    resolve(this.pythonKasaVersion);
+                }
+            });
+        });
+    }
+
 }
 
 module.exports = KasaLightstripPlatform;

--- a/lib/KasaLightstripPlatform.js
+++ b/lib/KasaLightstripPlatform.js
@@ -45,7 +45,7 @@ class KasaLightstripPlatform {
 
                                 const uuid = this.api.hap.uuid.generate('homebridge-kasa-lightstrip' + lightstrip.name + lightstrip.ip + customEffect.name);
                                 let accessory = this.accessories.find(accessory => accessory.UUID === uuid)
-                                new KasaLightEffect(this.log, lightstrip, customEffect.json, this.api, this.debug, uuid, accessory, customEffect.name);
+                                new KasaLightEffect(this.log, lightstrip, customEffect.json, this.api, this.debug, this.deviceString, uuid, accessory, customEffect.name);
                             }
                             
                         //Pre-defined Kasa Effects
@@ -55,7 +55,7 @@ class KasaLightstripPlatform {
                             let accessory = this.accessories.find(accessory => accessory.UUID === uuid)
 
                             if (lightstrip.effects[effect] == true) {
-                                new KasaLightEffect(this.log, lightstrip, effect, this.api, this.debug, uuid, accessory);
+                                new KasaLightEffect(this.log, lightstrip, effect, this.api, this.debug, this.deviceString, uuid, accessory);
                             } else {
                                 if (accessory) this.removeAccessory(accessory);  //remove any existing, disabled effects
                             }


### PR DESCRIPTION
…the number of warning messages (as well as display proper info!)

2) Thie bigger issue: python-kasa now wants --type lightstrip, and has deprecated --lightstrip. So, upon init, check version of PK. If 0.4.0, use old style. If 0.4.1 or newer, use new style. Place most parsing code in try/catch blocks. Failures result in version 0.0.0 getting set, which in turn causes an informational message pointing to the README.md for installing python-kasa.
I've tried to do this all in such a way that it a) avoids bringing down Homebridge in the event of errors, b) is persistent about warnings. It's easy to miss them in the log if they only happen at init.